### PR TITLE
Mapping JERM to Dublin Core Terms

### DIFF
--- a/JERM.owl
+++ b/JERM.owl
@@ -8,6 +8,7 @@
      ontologyIRI="http://jermontology.org/ontology/JERMOntology">
     <Prefix name="" IRI="http://jermontology.org/ontology/JERMOntology"/>
     <Prefix name="dc" IRI="http://purl.org/dc/elements/1.1/"/>
+    <Prefix name="dct" IRI="http://purl.org/dc/terms/"/>
     <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
     <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
     <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
@@ -6476,6 +6477,184 @@ Liquid chromatography (LC) is a separation technique in which the mobile phase i
         <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
         <AbbreviatedIRI>prov:wasInfluencedBy</AbbreviatedIRI>
         <IRI>http://www.w3.org/ns/prov-o#</IRI>
+    </AnnotationAssertion>
+
+    <Declaration>
+        <DataProperty abbreviatedIRI="dct:date"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty abbreviatedIRI="dct:description"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="dct:isFormatOf"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="dct:PhysicalResource"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="dct:format"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="dct:isPartOf"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty abbreviatedIRI="dct:title"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="dct:Agent"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="dct:creator"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty abbreviatedIRI="dct:identifier"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="dct:contributor"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="dct:MethodOfInstruction"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="dct:FileFormat"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="dct:hasPart"/>
+    </Declaration>
+    <SubClassOf>
+        <Class IRI="#Format"/>
+        <Class abbreviatedIRI="dct:FileFormat"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#Material_entity"/>
+        <Class abbreviatedIRI="dct:PhysicalResource"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#Person"/>
+        <Class abbreviatedIRI="dct:Agent"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#Protocol"/>
+        <Class abbreviatedIRI="dct:MethodOfInstruction"/>
+    </SubClassOf>
+    <EquivalentObjectProperties>
+        <ObjectProperty IRI="#hasPart"/>
+        <ObjectProperty abbreviatedIRI="dct:hasPart"/>
+    </EquivalentObjectProperties>
+    <EquivalentObjectProperties>
+        <ObjectProperty IRI="#isPartOf"/>
+        <ObjectProperty abbreviatedIRI="dct:isPartOf"/>
+    </EquivalentObjectProperties>
+    <SubObjectPropertyOf>
+        <ObjectProperty IRI="#hasContributor"/>
+        <ObjectProperty abbreviatedIRI="dct:contributor"/>
+    </SubObjectPropertyOf>
+    <SubObjectPropertyOf>
+        <ObjectProperty IRI="#hasCreator"/>
+        <ObjectProperty abbreviatedIRI="dct:creator"/>
+    </SubObjectPropertyOf>
+    <SubObjectPropertyOf>
+        <ObjectProperty IRI="#hasFormat"/>
+        <ObjectProperty abbreviatedIRI="dct:format"/>
+    </SubObjectPropertyOf>
+    <DisjointObjectProperties>
+        <ObjectProperty IRI="#isFormatOf"/>
+        <ObjectProperty abbreviatedIRI="dct:isFormatOf"/>
+    </DisjointObjectProperties>
+    <EquivalentDataProperties>
+        <DataProperty IRI="#description"/>
+        <DataProperty abbreviatedIRI="dct:description"/>
+    </EquivalentDataProperties>
+    <EquivalentDataProperties>
+        <DataProperty IRI="#identifier"/>
+        <DataProperty abbreviatedIRI="dct:identifier"/>
+    </EquivalentDataProperties>
+    <EquivalentDataProperties>
+        <DataProperty IRI="#title"/>
+        <DataProperty abbreviatedIRI="dct:title"/>
+    </EquivalentDataProperties>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#dateOfDeath"/>
+        <DataProperty abbreviatedIRI="dct:date"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#donationDate"/>
+        <DataProperty abbreviatedIRI="dct:date"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#samplingDate"/>
+        <DataProperty abbreviatedIRI="dct:date"/>
+    </SubDataPropertyOf>
+
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:Agent</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:FileFormat</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:MethodOfInstruction</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:PhysicalResource</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:contributor</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:creator</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:date</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:description</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:format</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:hasPart</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:identifier</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:isFormatOf</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:isPartOf</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
+        <AbbreviatedIRI>dct:title</AbbreviatedIRI>
+        <AbbreviatedIRI>dct:</AbbreviatedIRI>
     </AnnotationAssertion>
 </Ontology>
 


### PR DESCRIPTION
Partial fix for #2

http://dublincore.org/documents/dcmi-terms/
http://purl.org/dc/terms/

I've included `rdfs:isDefinedBy http://purl.org/dc/terms/` annotations for each of the cited terms - avoiding an OWL import of the full http://purl.org/dc/terms/


## Property equivalence

* jerm:title == dcterms:title
* jerm:description == dcterms:description
* jerm:identifier == dcterms:identifier
* jerm:hasPart == dcterms:hasPart
* jerm:isPartOf == dcterms:isPartOf

(The above would make SEEK's output using dcterms conform to the JERM ontology)

## Subproperties

Typically because the JERM properties have more specific domains/ranges:

* jerm:hasCreator < dcterms:creator
* jerm:hasContributor < dcterms:contributor
* jerm:hasFormat < dcterms:format 

## Disjoint properties

Some similarly named properties which are not compatible are marked as such:

* jerm:hasFormat != dcterms:hasFormat
* jerm:isFormatOf != dcterms:isFormatOf

(See http://dublincore.org/documents/dcmi-terms/#terms-hasFormat - both of these point to "A related resource that is substantially the same as the pre-existing described resource, but in another format." rather than the class-like "file format" resource)

## Date properties

These date properties are subproperties of dct:date

* jerm:dateOfDeath
* jerm:donationDate
* jerm:samplingDate

## Subclasses

DC Terms does not have many relevant classes as it focuses on the bibliography aspects, but I've mapped:

* jerm:Person < dct:Agent
* jerm:Protocol < dct:MethodOfInstruction
* jerm:Format < dct:FileFormat  (might be equivalent?)
* jerm:Material_entity < dct:PhysicalResource (might be equivalent?)

## Questions

Note that from JERM we already have the confusing `jerm:Software < jerm:Equipment < jerm:Material_entity` which then now would also become a `dct:PhysicalResource` - but the software might not be on a floppy! :)



